### PR TITLE
Changed references of calc to calctex. Added comment to README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,1 +1,7 @@
 Install this Spacemacs layer by cloning it to your local layers directory, ~$HOME/.spacemacs.d/layers~.
+
+Next, rename calctex-layers to calctex
+
+~cd $HOME/.spacemacs.d/layers~
+
+~mv calctex-laters calctex~

--- a/packages.el
+++ b/packages.el
@@ -18,18 +18,18 @@
 ;;
 ;;
 ;; Briefly, each package to be installed or configured by this layer should be
-;; added to `calc-packages'. Then, for each package PACKAGE:
+;; added to `calctex-packages'. Then, for each package PACKAGE:
 ;;
 ;; - If PACKAGE is not referenced by any other Spacemacs layer, define a
-;;   function `calc/init-PACKAGE' to load and initialize the package.
+;;   function `calctex/init-PACKAGE' to load and initialize the package.
 
 ;; - Otherwise, PACKAGE is already referenced by another Spacemacs layer, so
-;;   define the functions `calc/pre-init-PACKAGE' and/or
-;;   `calc/post-init-PACKAGE' to customize the package as it is loaded.
+;;   define the functions `calctex/pre-init-PACKAGE' and/or
+;;   `calctex/post-init-PACKAGE' to customize the package as it is loaded.
 
 ;;; Code:
 
-(defconst calc-packages '((calctex :location local)))
+(defconst calctex-packages '((calctex :location local)))
 
   "The list of Lisp packages required by the calc layer.
 
@@ -58,10 +58,10 @@ Each entry is either:
       - A list beginning with the symbol `recipe' is a melpa
         recipe.  See: https://github.com/milkypostman/melpa#recipe-format"
 
-(defun calc/init-calctex ()
+(defun calctex/init-calctex ()
     (use-package calctex))
 
-(defun calc/init-org-calctex ()
+(defun calctex/init-org-calctex ()
   (use-package org-calctex
     :after (calctex org)))
 


### PR DESCRIPTION
Thank you so much! I changed a couple of things to make this work. There were references to calc that had to be changed to calctex; also, if a user wants the layer instead, they might just call this package calctex, after renaming the package from calctex-layer to calctex. 

And, hey, my first pull request !